### PR TITLE
Fix broken demo-stand in Firefox

### DIFF
--- a/2-ui/3-event-details/9-keyboard-events/keyboard-dump.view/script.js
+++ b/2-ui/3-event-details/9-keyboard-events/keyboard-dump.view/script.js
@@ -5,7 +5,7 @@ var lastTime = Date.now();
 function handle(e) {
   if (form.elements[e.type + 'Ignore'].checked) return;
 
-  var text = event.type +
+  var text = e.type +
     ' keyCode=' + e.keyCode +
     ' which=' + e.which +
     ' charCode=' + e.charCode +


### PR DESCRIPTION
Demo stand at this moment doesn't work in Firefox on Mac OS X.