### PR TITLE
Fix node insertion among descendants

### DIFF
--- a/11-extra/9-drag-and-drop-plus/TreeDropTarget.js
+++ b/11-extra/9-drag-and-drop-plus/TreeDropTarget.js
@@ -64,6 +64,7 @@
      if (childTitle > title) {
        break;
      }
+     li = null;
    }
 
    ul.insertBefore(elemToMove, li);

--- a/11-extra/9-drag-and-drop-plus/dragTree.view/TreeDropTarget.js
+++ b/11-extra/9-drag-and-drop-plus/dragTree.view/TreeDropTarget.js
@@ -64,6 +64,7 @@
      if (childTitle > title) {
        break;
      }
+     li = null;
    }
 
    ul.insertBefore(elemToMove, li);


### PR DESCRIPTION
In case when break statement is not used within for loop we insert draggable node before the last child instead appending after it.