### PR TITLE
Удалить лишние операторы '+' у аргументов.

### DIFF
--- a/1-js/6-objects-more/3-constructor-new/4-calculator-extendable/solution.md
+++ b/1-js/6-objects-more/3-constructor-new/4-calculator-extendable/solution.md
@@ -23,7 +23,7 @@ function Calculator() {
       return NaN;
     }
 
-    return methods[op](+a, +b);
+    return methods[op](a, b);
   }
 
   this.addMethod = function(name, func) {


### PR DESCRIPTION
Удалить лишние операторы '+' у аргументов в описании решения задачи в соответствии с кодом решения в песочнице.