### PR TITLE
Разделение "</script>"

### DIFF
--- a/7-frames-and-windows/1-window-methods/article.md
+++ b/7-frames-and-windows/1-window-methods/article.md
@@ -140,7 +140,7 @@ newWin.onload = function() {
 var newWin = window.open("about:blank", "hello", "width=200,height=200");
 
 newWin.document.write(
-  "<script>*!*window.opener.document.body.innerHTML = 'Test'*/!*</script>"
+  "<script>*!*window.opener.document.body.innerHTML = 'Test'*/!*</scr" + "ipt>"
 );
 ```
 


### PR DESCRIPTION
Чтобы пример заработал в Plunker'е, требуется разделить "</script>" на "</scr"+"ipt>"

(Пример в пункте "Связь между окнами – двухсторонняя."
https://learn.javascript.ru/window-methods#доступ-к-новому-окну )