### PR TITLE
Неправильный пример преобразования

### DIFF
--- a/1-js/10-es-modern/8-symbol/article.md
+++ b/1-js/10-es-modern/8-symbol/article.md
@@ -181,10 +181,10 @@ let obj = {
 }
 
 // один символ в объекте
-alert( Object.getOwnPropertySymbols(obj) ); // Symbol(Symbol.iterator)
+alert( Object.getOwnPropertySymbols(obj)[0].toString() ); // Symbol(Symbol.iterator)
 
 // и одно обычное свойство
-alert( Object.getOwnPropertyNames(obj) ); // iterator
+alert( Object.getOwnPropertyNames(obj)[0].toString() ); // iterator
 ```
 
 ## Итого


### PR DESCRIPTION
Пример не работает и вызывает ошибку _Uncaught TypeError: Cannot convert a Symbol value to a string_
Это бы сработало, если результат выводить в консоль, но не сработает при использовании alert'а. Если выполнить преобразование вручную ( Object.getOwnPropertyNames(obj)[0].toString() ), проблем не будет.