### PR TITLE
Update article.md

### DIFF
--- a/1-js/02-first-steps/13-switch/article.md
+++ b/1-js/02-first-steps/13-switch/article.md
@@ -129,7 +129,7 @@ switch (a) {
   case 3:                    // (*) grouped two cases
   case 5:
     alert('Wrong!');
-    alert('How about to take maths classes?');
+    alert('Why don't you take a math class?');
     break;
 */!*
 


### PR DESCRIPTION
That English is not idiomatic at all.  You could says:

"Why don't you take a math class?"
or
"How about taking a math class?"

Also, you may want to consider using American English, and in this case, please use "math" not "maths".  The US is a bigger market than the UK, is more widely used, the US is the center of the tech industry, etc.  The standard for using English-language variables in code comes from the US, not England.  And British-English is annoying. ;) :)