### PR TITLE
Symbol type patch

### DIFF
--- a/1-js/04-object-basics/03-symbol/article.md
+++ b/1-js/04-object-basics/03-symbol/article.md
@@ -144,7 +144,7 @@ let obj = {
   0: "test" // same as "0": "test"
 }
 
-// bot alerts access the same property (the number 0 is converted to string "0")
+// both alerts access the same property (the number 0 is converted to string "0")
 alert( obj["0"] ); // test
 alert( obj[0] ); // test (same property)
 ```

--- a/1-js/04-object-basics/03-symbol/article.md
+++ b/1-js/04-object-basics/03-symbol/article.md
@@ -102,7 +102,7 @@ Symbolic properties do not participate in `for..in` loop.
 For instance:
 
 ```js run
-let id = Symbol("id");
+let id = Symbol.for("id");
 let user = {
   name: "John",
   age: 30,


### PR DESCRIPTION
Hello!

As suggested by Helena Munzarová, there's a small error inside this example: http://javascript.info/symbol#symbols-skipped-by-for-in

The symbol cannot be accessed by the global symbol registry, because it wasn't created by Symbol.for. Changing the first line to let id = Symbol.for("id"); works OK.

Besides this, I've also corrected a misspelling.