### PR TITLE
Update article.md

### DIFF
--- a/2-ui/2-events/02-bubbling-and-capturing/article.md
+++ b/2-ui/2-events/02-bubbling-and-capturing/article.md
@@ -193,7 +193,7 @@ The event handling process:
 Each handler can access `event` object properties:
 
 - `event.target` -- the deepest element that originated the event.
-- `event.currentTarget` (=`this`) -- the current element the handles the event (the one that has the handler on it)
+- `event.currentTarget` (=`this`) -- the current element that handles the event (the one that has the handler on it)
 - `event.eventPhase` -- the current phase (capturing=1, bubbling=3).
 
 Any event handler can stop the event by calling `event.stopPropagation()`, but that's not recommended, because we can't really be sure we won't need it above, maybe for completely different things.


### PR DESCRIPTION
Hi,

I suggest a typo correction from "the" to "that" found in the summary. 

- `event.currentTarget` (=`this`) -- the current element <that> handles the event (the one that has the handler on it)

I'm new to github, so I'm welcome to any tips on writing better descriptions and proposals.

Thank you for the helpful article. 